### PR TITLE
fix: dagger 2.12+

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -28,12 +28,13 @@ ext {
     supportLibraryVersion = '27.0.2'
     timberVersion = '4.5.1'
     glideVersion = '4.6.1'
-    daggerVersion = '2.11'
+    daggerVersion = '2.14.1'
     glassfishAnnotationVersion = '10.0-b28'
     archLifecycle = '1.1.0'
     roomVersion = '1.1.0-alpha1'
     autoValue = '1.5'
     autoValueGson = '0.7.0'
+    autoValueAnnotation = autoValue
 
     //Testing
     robolectricVersion = '3.4.2'
@@ -233,6 +234,9 @@ ext {
 
             autoValue:          "com.google.auto.value:auto-value:${autoValue}",
             autoValueGson:      "com.ryanharter.auto.value:auto-value-gson:${autoValueGson}",
+
+            autoValueAnnotation:"com.jakewharton.auto.value:auto-value-annotations:${autoValueAnnotation}",
+            gson:               "com.google.code.gson:gson:${gsonVersion}",
     ]
 
 }

--- a/mobile-ui/build.gradle
+++ b/mobile-ui/build.gradle
@@ -16,6 +16,12 @@ android {
         targetSdkVersion globalConfiguration["androidTargetSdkVersion"]
         multiDexEnabled = true
         testInstrumentationRunner "com.playone.mobile.ui.test.TestRunner"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                includeCompileClasspath false
+            }
+        }
     }
 
     buildTypes {
@@ -126,16 +132,17 @@ dependencies {
     kaptTest mobileUiDependencies.archLifecycleCompiler
 
     // Auto-Value
-    annotationProcessor developmentDependencies.autoValue
-    compileOnly developmentDependencies.autoValue
-    testAnnotationProcessor developmentDependencies.autoValue
-    androidTestAnnotationProcessor developmentDependencies.autoValue
+    kapt developmentDependencies.autoValue
+    compileOnly developmentDependencies.autoValueAnnotation
+    kaptTest developmentDependencies.autoValue
+    kaptAndroidTest developmentDependencies.autoValue
 
     // AutoValue Type Adapter
-    annotationProcessor developmentDependencies.autoValueGson
-    compileOnly developmentDependencies.autoValueGson
-    testAnnotationProcessor developmentDependencies.autoValueGson
-    androidTestAnnotationProcessor developmentDependencies.autoValueGson
+    kapt developmentDependencies.autoValueGson
+    kaptTest developmentDependencies.autoValueGson
+    kaptAndroidTest developmentDependencies.autoValueGson
+
+    implementation developmentDependencies.gson
 
     // Instrumentation test dependencies
     androidTestImplementation mobileUiTestDependencies.junit


### PR DESCRIPTION
Issue: https://github.com/google/dagger/issues/897

- If use 
``` 
compileOnly developmentDependencies.autoValue
compileOnly developmentDependencies.autoValueGson
```
will cause runtime crash

solved:
use https://github.com/JakeWharton/AutoValueAnnotations instead