### PR TITLE
Added that retrieving the user and playone entity

### DIFF
--- a/data/src/main/java/com/playone/mobile/data/model/UserEntity.kt
+++ b/data/src/main/java/com/playone/mobile/data/model/UserEntity.kt
@@ -10,6 +10,7 @@ data class UserEntity(
     var pictureURL: String = "",
     var description: String = "",
     var grade: String = "",
+    var deviceToken: String = "",
     var age: Int = 0,
     var level: Int = 0,
     var years: Int = 0,

--- a/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/PlayoneFirebaseV1.kt
+++ b/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/PlayoneFirebaseV1.kt
@@ -1,10 +1,7 @@
 package com.playone.mobile.ui.firebase.v1
 
 import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.DatabaseReference
-import com.google.firebase.database.MutableData
-import com.google.firebase.database.Query
 import com.google.firebase.database.Transaction
 import com.google.firebase.iid.FirebaseInstanceId
 import com.playone.mobile.ext.isNotNull
@@ -424,43 +421,11 @@ class PlayoneFirebaseV1(
                                 ::snapToPlayone)
         }
     }
-//endregion
+    //endregion
 
-    //region Extension function
     private fun toPlayoneModel(dataSnapshot: DataSnapshot) = dataSnapshot.run {
         getValue(PlayoneModel::class.java)
             .takeIf { it.isNotNull() && key.isNotNull() }
             ?.also { it.id = key }
     }
-
-    private fun DatabaseError.makeCallback(errorCallback: FirebaseErrorCallback) =
-        errorCallback(code, message, details)
-
-    private fun <D> Query.addStrategyListener(
-        callback: PlayoneCallback<D>,
-        errorCallback: FirebaseErrorCallback,
-        strategy: DataSnapStrategy<D>
-    ) = addListenerForSingleValueEvent {
-        onDataChange = { strategy?.apply { callback(this(it)) } }
-        onCancelled = { it.makeCallback(errorCallback) }
-    }
-
-    private fun <D> DatabaseReference.runTransaction(
-        callback: OperationResultCallback,
-        errorCallback: FirebaseErrorCallback,
-        strategy: TransactionDataSnapStrategy<D>,
-        block: (MutableData?) -> Transaction.Result
-    ) = runTransaction(object : Transaction.Handler {
-        override fun onComplete(de: DatabaseError, p1: Boolean, ds: DataSnapshot?) =
-            if (!p1) {
-                de.makeCallback(errorCallback)
-            }
-            else {
-                strategy?.invoke(de, p1, ds)
-                callback(p1)
-            }
-
-        override fun doTransaction(mutableData: MutableData?) = block(mutableData)
-    })
-    //endregion
 }

--- a/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/PlayoneFirebaseV1.kt
+++ b/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/PlayoneFirebaseV1.kt
@@ -154,6 +154,7 @@ class PlayoneFirebaseV1(
         callback: OperationResultCallback,
         errorCallback: FirebaseErrorCallback
     ) {
+        // TODO(jieyi): 2018/02/27 
     }
 
     override fun isJoined(
@@ -162,6 +163,7 @@ class PlayoneFirebaseV1(
         callback: OperationResultCallback,
         errorCallback: FirebaseErrorCallback
     ) {
+        // TODO(jieyi): 2018/02/27
     }
 
     //region Fetching data from firebase database.

--- a/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/PlayoneFirebaseV1.kt
+++ b/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/PlayoneFirebaseV1.kt
@@ -51,6 +51,19 @@ class PlayoneFirebaseV1(
         favoriteSnap2PlayoneList(it, errorCallback, callback)
     }
 
+    override fun getPlayoneDetail(
+        userId: Int,
+        callback: (model: PlayoneModel?) -> Unit,
+        errorCallback: FirebaseErrorCallback
+    ) = playoneDataSnapshot(userId.toString(), callback, errorCallback, ::snap2Playone)
+
+    override fun createPlayone(
+        userId: Int,
+        model: PlayoneModel,
+        callback: (isSuccess: Boolean) -> Unit,
+        errorCallback: FirebaseErrorCallback
+    ) = Unit
+
     //region Fetching data from firebase database.
     private fun <D> playoneDataSnapshot(
         callback: PlayoneCallback<D>,
@@ -100,6 +113,21 @@ class PlayoneFirebaseV1(
         .child(userId)
         .child(FAVORITES)
         .addStrategyListener(callback, errorCallback, strategy)
+
+    private fun playoneDataSnapshot(
+        test: Int,
+        userId: String,
+        callback: (isSuccess: Boolean) -> Unit,
+        errorCallback: FirebaseErrorCallback,
+        strategy: DataSnapStrategy<Boolean>
+    ) = dbReference
+        .child(USERS)
+        .child(userId)
+        .child(NAME)
+        .addListenerForSingleValueEvent {
+            onDataChange = { strategy?.apply { callback(this(it)) } }
+            onCancelled = { it.makeCallback(errorCallback) }
+        }
     //endregion
 
     //region Strategies of snapshot to the object.
@@ -151,6 +179,10 @@ class PlayoneFirebaseV1(
         ?.map { it.key }
         ?.toMutableSet()
         ?.run { byThruId(errorCallback, block) }
+
+    private fun snapToIsSuccess() {
+
+    }
 
     private fun MutableSet<String>.byThruId(
         errorCallback: FirebaseErrorCallback,

--- a/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/TypeAliases.kt
+++ b/mobile-ui/src/main/java/com/playone/mobile/ui/firebase/v1/TypeAliases.kt
@@ -1,8 +1,10 @@
 package com.playone.mobile.ui.firebase.v1
 
 import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
 
 typealias PlayoneCallback<D> = (model: D) -> Unit
 typealias FirebaseErrorCallback = (code: Int, msg: String, detail: String) -> Unit
 
 typealias DataSnapStrategy<D> = ((DataSnapshot?) -> D)?
+typealias TransactionDataSnapStrategy<D> = ((DatabaseError, Boolean, DataSnapshot?) -> D)?

--- a/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
@@ -28,4 +28,17 @@ abstract class PlayoneFirebase {
         callback: (model: List<PlayoneModel>) -> Unit,
         errorCallback: (code: Int, msg: String, detail: String) -> Unit
     )
+
+    abstract fun getPlayoneDetail(
+        userId: Int,
+        callback: (model: PlayoneModel?) -> Unit,
+        errorCallback: (code: Int, msg: String, detail: String) -> Unit
+    )
+
+    abstract fun createPlayone(
+        userId: Int,
+        model: PlayoneModel,
+        callback: (isSuccess: Boolean) -> Unit,
+        errorCallback: (code: Int, msg: String, detail: String) -> Unit
+    )
 }

--- a/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
@@ -1,6 +1,7 @@
 package com.playone.mobile.remote
 
 import com.playone.mobile.remote.model.PlayoneModel
+import com.playone.mobile.remote.model.UserModel
 
 abstract class PlayoneFirebase {
     protected val GROUPS = "groups"
@@ -10,10 +11,25 @@ abstract class PlayoneFirebase {
     protected val FAVORITES = "favorites"
     protected val TEAMS = "teams"
     protected val NAME = "name"
+    protected val DEVICE_TOKENS = "device_tokens"
 
     abstract fun getPlayoneList(
         userId: Int,
         callback: PlayoneListCallback,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun createPlayone(
+        userId: Int,
+        model: PlayoneModel,
+        callback: OperationResultCallback,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun updatePlayone(
+        id: Int,
+        model: PlayoneModel,
+        callback: OperationResultCallback,
         errorCallback: FirebaseErrorCallback
     )
 
@@ -22,7 +38,6 @@ abstract class PlayoneFirebase {
         callback: PlayoneListCallback,
         errorCallback: FirebaseErrorCallback
     )
-
     abstract fun getFavoritePlayoneList(
         userId: Int,
         callback: PlayoneListCallback,
@@ -32,13 +47,25 @@ abstract class PlayoneFirebase {
     abstract fun getPlayoneDetail(
         userId: Int,
         callback: (model: PlayoneModel?) -> Unit,
-        errorCallback: (code: Int, msg: String, detail: String) -> Unit
+        errorCallback: FirebaseErrorCallback
     )
 
-    abstract fun createPlayone(
+    abstract fun getUser(
         userId: Int,
-        model: PlayoneModel,
-        callback: (isSuccess: Boolean) -> Unit,
-        errorCallback: (code: Int, msg: String, detail: String) -> Unit
+        callback: (mode: UserModel?) -> Unit,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun createUser(
+        model: UserModel,
+        callback: (mode: UserModel?) -> Unit,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun updateUser(
+        model: UserModel,
+        lastDeviceToken: String,
+        callback: OperationResultCallback,
+        errorCallback: FirebaseErrorCallback
     )
 }

--- a/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
@@ -64,7 +64,7 @@ abstract class PlayoneFirebase {
 
     abstract fun updateUser(
         model: UserModel,
-        lastDeviceToken: String,
+        lastDeviceToken: String?,
         callback: OperationResultCallback,
         errorCallback: FirebaseErrorCallback
     )

--- a/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
@@ -1,5 +1,7 @@
 package com.playone.mobile.remote
 
+import com.playone.mobile.remote.model.PlayoneModel
+
 abstract class PlayoneFirebase {
     protected val GROUPS = "groups"
     protected val USERS = "users"

--- a/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/PlayoneFirebase.kt
@@ -38,6 +38,7 @@ abstract class PlayoneFirebase {
         callback: PlayoneListCallback,
         errorCallback: FirebaseErrorCallback
     )
+
     abstract fun getFavoritePlayoneList(
         userId: Int,
         callback: PlayoneListCallback,
@@ -65,6 +66,35 @@ abstract class PlayoneFirebase {
     abstract fun updateUser(
         model: UserModel,
         lastDeviceToken: String?,
+        callback: OperationResultCallback,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun joinTeamAsMember(
+        playoneId: Int,
+        userId: Int,
+        isJoin: Boolean,
+        callback: OperationResultCallback,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun toggleFavorite(
+        playoneId: Int,
+        userId: Int,
+        callback: OperationResultCallback,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun isFavorite(
+        playoneId: Int,
+        userId: Int,
+        callback: OperationResultCallback,
+        errorCallback: FirebaseErrorCallback
+    )
+
+    abstract fun isJoined(
+        playoneId: Int,
+        userId: Int,
         callback: OperationResultCallback,
         errorCallback: FirebaseErrorCallback
     )

--- a/remote/src/main/java/com/playone/mobile/remote/TypeAliases.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/TypeAliases.kt
@@ -4,3 +4,4 @@ import com.playone.mobile.remote.model.PlayoneModel
 
 typealias PlayoneListCallback = (model: List<PlayoneModel>) -> Unit
 typealias FirebaseErrorCallback = (code: Int, msg: String, detail: String) -> Unit
+typealias OperationResultCallback = (isSuccess: Boolean) -> Unit

--- a/remote/src/main/java/com/playone/mobile/remote/mapper/UserEntityMapper.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/mapper/UserEntityMapper.kt
@@ -9,10 +9,30 @@ import com.playone.mobile.remote.model.UserModel
  */
 class UserEntityMapper : EntityMapper<UserModel, UserEntity> {
     override fun mapToData(type: UserModel) = type.run {
-        UserEntity(id, name, email, pictureURL, description, grade, age, level, years, teams)
+        UserEntity(id,
+                   name,
+                   email,
+                   pictureURL,
+                   description,
+                   grade,
+                   deviceToken,
+                   age,
+                   level,
+                   years,
+                   teams)
     }
 
     override fun mapFromData(type: UserEntity) = type.run {
-        UserModel(id, name, email, pictureURL, description, grade, age, level, years, teams)
+        UserModel(id,
+                  name,
+                  email,
+                  pictureURL,
+                  description,
+                  grade,
+                  deviceToken,
+                  age,
+                  level,
+                  years,
+                  teams)
     }
 }

--- a/remote/src/main/java/com/playone/mobile/remote/model/PlayoneModel.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/model/PlayoneModel.kt
@@ -16,4 +16,17 @@ data class PlayoneModel(
     var level: Int = 0,
     var host: String = "",
     var userId: String = ""
-)
+) {
+    fun toMap() = hashMapOf("name" to name,
+                            "name" to name,
+                            "description" to description,
+                            "host" to host,
+                            "date" to date,
+                            "updated" to updated,
+                            "address" to address,
+                            "latitude" to latitude,
+                            "longitude" to longitude,
+                            "limit" to limit,
+                            "level" to level,
+                            "userId" to userId)
+}

--- a/remote/src/main/java/com/playone/mobile/remote/model/UserModel.kt
+++ b/remote/src/main/java/com/playone/mobile/remote/model/UserModel.kt
@@ -10,6 +10,7 @@ data class UserModel(
     var pictureURL: String = "",
     var description: String = "",
     var grade: String = "",
+    var deviceToken: String = "",
     var age: Int = 0,
     var level: Int = 0,
     var years: Int = 0,


### PR DESCRIPTION
The `remote_api` branch is till running, this is for avoiding the PR became hugh.

- Add all operations about the playone entity.
- Add all operations about the user entity.